### PR TITLE
Fix/fork pr racecondition

### DIFF
--- a/gato/attack/attack.py
+++ b/gato/attack/attack.py
@@ -130,8 +130,21 @@ class Attacker:
                 print(f"{RED_DASH} Error while forking repository!")
                 return False
 
-            # Sanity check for integration test.
-            time.sleep(30)
+            for i in range(self.timeout):
+                status = self.api.get_repository(repo_name)
+                if status:
+                    print(
+                        f"{GREEN_PLUS} Successfully created fork: {repo_name}!"
+                    )
+                else:
+                    time.sleep(1)
+
+            if not status:
+                print(
+                    f"{RED_DASH} Forked repository not found after "
+                    f"{self.timeout} seconds!"
+                )
+                return False
 
             cloned_repo = Git(
                 self.api.pat,
@@ -198,11 +211,6 @@ class Attacker:
                     if push_status:
                         print(f"{GREEN_PLUS} Pushed commit to close PR!")
 
-                print(
-                    f"{GREEN_PLUS} Sleeping 25 seconds to allow"
-                    " PR to close before deleting fork repo!"
-                )
-                time.sleep(25)
             else:
                 print(f"{RED_DASH} Failed to create a PR for the fork!")
 

--- a/gato/attack/attack.py
+++ b/gato/attack/attack.py
@@ -136,6 +136,7 @@ class Attacker:
                     print(
                         f"{GREEN_PLUS} Successfully created fork: {repo_name}!"
                     )
+                    break
                 else:
                     time.sleep(1)
 

--- a/gato/attack/attack.py
+++ b/gato/attack/attack.py
@@ -130,6 +130,9 @@ class Attacker:
                 print(f"{RED_DASH} Error while forking repository!")
                 return False
 
+            # Sanity check for integration test.
+            time.sleep(30)
+
             cloned_repo = Git(
                 self.api.pat,
                 repo_name,

--- a/gato/cli/cli.py
+++ b/gato/cli/cli.py
@@ -375,7 +375,8 @@ def configure_parser_attack(parser):
         "--timeout", "-to",
         metavar="SECONDS",
         help="Timeout, in seconds, to wait for the Action to queue and\n"
-        "execute. Defaults to '30'",
+        "execute. For fork PR attacks, this is the time, in seconds, to wait "
+        "for the fork repository to be created. Defaults to '30'",
         default="30",
         type=int
     )


### PR DESCRIPTION
This fixes the issue where if the fork is not immediately created on GitHub.com, the fork PR attack fails. The fix involves calling the `get_repository` API call every second. Gato will only proceed with the clone operation once the `get_repository` confirms that the fork has been created.