### PR TITLE
Improve permission error handling for search module.

### DIFF
--- a/gato/github/search.py
+++ b/gato/github/search.py
@@ -70,6 +70,14 @@ class Search():
 
             return set(candidates)
         else:
-            print('[-] Secondary rate limit hit!')
-            # TODO: Check for auth issues here too!
+            if result.status_code == 403:
+                print('[-] Secondary rate limit hit!')
+            elif result.status_code == 422:
+                print('[-] Search failed with reponse code 422!')
+                context = result.json()
+
+                if 'errors' in context and len(context['errors']) > 0:
+                    print("\tError message from GitHub:\n"
+                          f"\t{context['errors'][0]['message']}")
+
             return set()


### PR DESCRIPTION
When using the search API, if the organization being searched for requires SSO, does not exist, or is private (and the user does not have read access), then the API will return a 422 code. Currently, gato does not detect this and fails with a misleading message.

This fix updates the error handling to inform the user that the API call failed with a 422 code, and passes the github error message to the user.