### PR TITLE
Add custom GitHub target support

### DIFF
--- a/gato/attack/attack.py
+++ b/gato/attack/attack.py
@@ -24,13 +24,15 @@ class Attacker:
         http_proxy: str = None,
         author_email: str = None,
         author_name: str = None,
-        timeout: int = 30
+        timeout: int = 30,
+        github_url: str = None,
     ):
 
         self.api = Api(
             pat,
             socks_proxy=socks_proxy,
             http_proxy=http_proxy,
+            github_url=github_url,
         )
 
         self.socks_proxy = socks_proxy

--- a/gato/attack/attack.py
+++ b/gato/attack/attack.py
@@ -41,6 +41,7 @@ class Attacker:
         self.author_email = author_email
         self.author_name = author_name
         self.timeout = timeout
+        self.github_url = github_url
 
     def __setup_user_info(self):
         if not self.user_perms:
@@ -140,7 +141,8 @@ class Attacker:
                 repo_name,
                 proxies=self.api.proxies,
                 username=self.author_name,
-                email=self.author_email
+                email=self.author_email,
+                github_url=self.github_url.split('/')[2] if self.github_url else None
             )
 
             for i in range(self.timeout):
@@ -246,7 +248,8 @@ class Attacker:
                 target_repo,
                 proxies=self.api.proxies,
                 username=self.author_name,
-                email=self.author_email
+                email=self.author_email,
+                github_url=self.github_url.split('/')[2] if self.github_url else None
             )
             cloned_repo.perform_clone()
 

--- a/gato/cli/cli.py
+++ b/gato/cli/cli.py
@@ -40,7 +40,7 @@ def cli(args):
     parser.add_argument(
         "--api-url", "-u",
         help=(
-            f"{Fore.RED}{bright('!! Experimental !!')}\n"
+            f"{Fore.RED}{Output.bright('!! Experimental !!')}\n"
             "Github API URL to target. \n"
             "Defaults to 'https://api.github.com'"
         ),

--- a/gato/cli/cli.py
+++ b/gato/cli/cli.py
@@ -44,7 +44,7 @@ def cli(args):
             "Github API URL to target. \n"
             "Defaults to 'https://api.github.com'"
         ),
-        metavar="https://api.github-url.com",
+        metavar="https://api.github-url.com/api/v3",
         default="https://api.github.com",
         required=False,
     )

--- a/gato/cli/cli.py
+++ b/gato/cli/cli.py
@@ -37,6 +37,18 @@ def cli(args):
 
     configure_parser_general(parser)
 
+    parser.add_argument(
+        "--api-url", "-u",
+        help=(
+            f"{Fore.RED}{bright('!! Experimental !!')}\n"
+            "Github API URL to target. \n"
+            "Defaults to 'https://api.github.com'"
+        ),
+        metavar="https://api.github-url.com",
+        default="https://api.github.com",
+        required=False,
+    )
+
     attack_parser = subparsers.add_parser(
         "attack", help="CI/CD Attack Capabilities", aliases=["a"],
         formatter_class=argparse.RawTextHelpFormatter
@@ -146,7 +158,8 @@ def attack(args, parser):
         author_name=args.author_name,
         socks_proxy=args.socks_proxy,
         http_proxy=args.http_proxy,
-        timeout=timeout
+        timeout=timeout,
+        github_url=args.api_url
     )
 
     if args.pull_request:
@@ -206,6 +219,7 @@ def enumerate(args, parser):
             skip_clones=args.skip_clones,
             output_yaml=args.output_yaml,
             skip_log=args.skip_runlog,
+            github_url=args.api_url
         )
 
     if args.self_enumeration:
@@ -236,7 +250,8 @@ def search(args, parser):
     gh_search_runner = Searcher(
         args.gh_token,
         socks_proxy=args.socks_proxy,
-        http_proxy=args.http_proxy
+        http_proxy=args.http_proxy,
+        github_url=args.api_url
     )
 
     gh_search_runner.use_search_api(args.target)

--- a/gato/enumerate/enumerate.py
+++ b/gato/enumerate/enumerate.py
@@ -23,8 +23,8 @@ class Enumerator:
         http_proxy: str = None,
         skip_clones: bool = False,
         output_yaml: str = None,
-        skip_log: bool = False
         skip_log: bool = False,
+        github_url: str = None
     ):
         """Initialize enumeration class with arguments sent by user.
 

--- a/gato/enumerate/enumerate.py
+++ b/gato/enumerate/enumerate.py
@@ -24,6 +24,7 @@ class Enumerator:
         skip_clones: bool = False,
         output_yaml: str = None,
         skip_log: bool = False
+        skip_log: bool = False,
     ):
         """Initialize enumeration class with arguments sent by user.
 
@@ -46,6 +47,7 @@ class Enumerator:
             pat,
             socks_proxy=socks_proxy,
             http_proxy=http_proxy,
+            github_url=github_url,
         )
 
         self.socks_proxy = socks_proxy

--- a/gato/enumerate/enumerate.py
+++ b/gato/enumerate/enumerate.py
@@ -56,6 +56,7 @@ class Enumerator:
         self.skip_log = skip_log
         self.output_yaml = output_yaml
         self.user_perms = None
+        self.github_url = github_url
 
     def __setup_user_info(self):
         if not self.user_perms:
@@ -192,6 +193,7 @@ class Enumerator:
             self.api.pat,
             repository.name,
             proxies=self.api.proxies,
+            github_url=self.github_url.split('/')[2] if self.github_url else None
         )
 
         status = cloned_repo.perform_clone()

--- a/gato/git/git.py
+++ b/gato/git/git.py
@@ -13,7 +13,8 @@ class Git:
     """
 
     def __init__(self, pat, repo_name: str, username="Gato",
-                 email="gato@gato.infosec", proxies=None):
+                 email="gato@gato.infosec", proxies=None,
+                 github_url="github.com"):
         """Initialize the git abstraction class. This class managed a
         checked-out git repository located in a temporary directory.
 
@@ -31,13 +32,17 @@ class Git:
             Defaults to None.
         """
         self.cloned = False
-        if proxies:
+        self.github_url = github_url
+
+        if self.github_url != "github.com" or proxies:
             os.environ["GIT_SSL_NO_VERIFY"] = 'True'
+
+        if proxies:
             os.environ["ALL_PROXY"] = proxies["https"]
 
         self.clone_comamnd = (
             "git clone --depth 1 --filter=blob:none --sparse"
-            f" https://{pat}@github.com/{repo_name}"
+            f" https://{pat}@{self.github_url}/{repo_name}"
         )
 
         self.config_command1 = (

--- a/gato/github/api.py
+++ b/gato/github/api.py
@@ -60,6 +60,10 @@ class Api():
                 'https': f'socks5://{socks_proxy}'
             }
 
+        if self.github_url != "https://api.github.com":
+            self.verify_ssl = False
+            requests.packages.urllib3.disable_warnings()
+
     def __process_run_log(self, log_content: bytes, run_info: dict):
         """Utility method to process a run log zip file.
 

--- a/gato/github/api.py
+++ b/gato/github/api.py
@@ -164,7 +164,7 @@ class Api():
             url (stre): _description_
             params (dict, optional): _description_. Defaults to None.
         """
-        request_url = Api.GITHUB_URL + url
+        request_url = self.github_url + url
         logger.debug(f'Making PUT API request to {request_url}!')
 
         api_response = requests.put(request_url, headers=self.headers,

--- a/gato/github/api.py
+++ b/gato/github/api.py
@@ -40,7 +40,7 @@ class Api():
             'Authorization': f'Bearer {pat}',
             'X-GitHub-Api-Version': version
         }
-        self.GITHUB_URL = github_url
+        self.github_url = github_url
 
         if http_proxy and socks_proxy:
             raise ValueError('A SOCKS & HTTP proxy cannot be used at the same '
@@ -107,7 +107,7 @@ class Api():
         Returns:
             Response: Returns the requests response object.
         """
-        request_url = self.GITHUB_URL + url
+        request_url = self.github_url + url
 
         logger.debug(f'Making GET API request to {request_url}!')
         api_response = requests.get(request_url, headers=self.headers,
@@ -130,7 +130,7 @@ class Api():
         Returns:
             Response: Returns the requests response object.
         """
-        request_url = self.GITHUB_URL + url
+        request_url = self.github_url + url
         logger.debug(f'Making POST API request to {request_url}!')
 
         api_response = requests.post(request_url, headers=self.headers,
@@ -153,7 +153,7 @@ class Api():
         Returns:
             Response: Returns the requests response object.
         """
-        request_url = self.GITHUB_URL + url
+        request_url = self.github_url + url
         logger.debug(f'Making DELETE API request to {request_url}!')
 
         api_response = requests.delete(request_url, headers=self.headers,

--- a/gato/github/api.py
+++ b/gato/github/api.py
@@ -13,12 +13,12 @@ class Api():
     rate limiting or network issues.
     """
 
-    GITHUB_URL = "https://api.github.com"
     RUNNER_RE = re.compile(r'Runner name: \'([\w+-]+)\'')
     MACHINE_RE = re.compile(r'Machine name: \'([\w+-]+)\'')
 
     def __init__(self, pat: str, version: str = "2022-11-28",
-                 http_proxy: str = None, socks_proxy: str = None):
+                 http_proxy: str = None, socks_proxy: str = None,
+                 github_url: str = "https://api.github.com"):
         """Initialize the API abstraction layer to interact with the GitHub
         REST API.
 
@@ -40,6 +40,7 @@ class Api():
             'Authorization': f'Bearer {pat}',
             'X-GitHub-Api-Version': version
         }
+        self.GITHUB_URL = github_url
 
         if http_proxy and socks_proxy:
             raise ValueError('A SOCKS & HTTP proxy cannot be used at the same '
@@ -106,7 +107,7 @@ class Api():
         Returns:
             Response: Returns the requests response object.
         """
-        request_url = Api.GITHUB_URL + url
+        request_url = self.GITHUB_URL + url
 
         logger.debug(f'Making GET API request to {request_url}!')
         api_response = requests.get(request_url, headers=self.headers,
@@ -129,7 +130,7 @@ class Api():
         Returns:
             Response: Returns the requests response object.
         """
-        request_url = Api.GITHUB_URL + url
+        request_url = self.GITHUB_URL + url
         logger.debug(f'Making POST API request to {request_url}!')
 
         api_response = requests.post(request_url, headers=self.headers,
@@ -152,7 +153,7 @@ class Api():
         Returns:
             Response: Returns the requests response object.
         """
-        request_url = Api.GITHUB_URL + url
+        request_url = self.GITHUB_URL + url
         logger.debug(f'Making DELETE API request to {request_url}!')
 
         api_response = requests.delete(request_url, headers=self.headers,

--- a/gato/search/search.py
+++ b/gato/search/search.py
@@ -16,7 +16,7 @@ class Searcher:
         self,
         pat: str,
         socks_proxy: str = None,
-        http_proxy: str = None
+        http_proxy: str = None,
         github_url: str = None,
     ):
         self.api = Api(

--- a/gato/search/search.py
+++ b/gato/search/search.py
@@ -17,11 +17,13 @@ class Searcher:
         pat: str,
         socks_proxy: str = None,
         http_proxy: str = None
+        github_url: str = None,
     ):
         self.api = Api(
             pat,
             socks_proxy=socks_proxy,
             http_proxy=http_proxy,
+            github_url=github_url,
         )
 
         self.socks_proxy = socks_proxy


### PR DESCRIPTION
Replaces #12 

We currently don't support user-defined Github API targets via the CLI. This PR allows the CLI user to specify the API target to use, but has not been tested against a GHES instance. This resolves #11 

The default API target is 'https://api.github.com/'.