### PR TITLE
Add enumeration for third-party checks on public fork PRs

### DIFF
--- a/gato/enumerate/repository.py
+++ b/gato/enumerate/repository.py
@@ -102,6 +102,9 @@ class RepositoryEnum():
             Output.error("The user cannot push or pull, skipping.")
             return
 
+        if repository.is_public():
+            self.enumerate_forkpr_checks(repository)
+
         if repository.is_admin():
             runners = self.api.get_repo_runners(repository.name)
 
@@ -158,3 +161,12 @@ class RepositoryEnum():
 
             if org_secrets:
                 repository.set_accessible_org_secrets(org_secrets)
+
+    def enumerate_forkpr_checks(self, repository: Repository):
+        """Enumerates checks associated with fork pull requests.
+
+        Args:
+            repository (Repository): Repository wrapper object
+        """
+        for check in self.api.get_fork_checks(repository.name):
+            repository.set_check(check)

--- a/gato/models/repository.py
+++ b/gato/models/repository.py
@@ -30,6 +30,7 @@ class Repository():
         self.sh_runner_access = False
         self.accessible_runners: List[Runner] = []
         self.runners: List[Runner] = []
+        self.checks = []
 
     def is_admin(self):
         return self.permission_data.get('admin', False)
@@ -83,6 +84,18 @@ class Repository():
         self.sh_runner_access = True
         self.runners = runners
 
+    def set_check(self, check: tuple):
+        """Set check information. 
+
+        Args:
+            checks (tuple): Tuple of three strings: URL, description, context
+        """
+        self.checks.append({
+            "URL": check[0],
+            "Description": check[1],
+            "Context": check[2]
+        })
+
     def add_self_hosted_workflows(self, workflows: list):
         """Add a list of workflow file names that run on self-hosted runners.
         """
@@ -112,6 +125,7 @@ class Repository():
             "repo_runners": [runner.toJSON() for runner in self.runners],
             "repo_secrets": [secret.toJSON() for secret in self.secrets],
             "org_secrets": [secret.toJSON() for secret in self.org_secrets],
+            "fork_pr_checks": self.checks,
         }
 
         return representation


### PR DESCRIPTION
Pull requests from fork PRs will sometimes trigger third-party CI/CD workflows. Some of these third-party systems might be vulnerable to attacks via malicious PR (e.g. Buildkite). This will help identify repositories for further investigation.