### PR TITLE
fix: Fix secrets attack bug if branch name contains hyphens

### DIFF
--- a/gato/attack/cicd_attack.py
+++ b/gato/attack/cicd_attack.py
@@ -94,7 +94,8 @@ class CICDAttack():
 
         echo_cmd += '"'
 
-        pkey_varname = f'{branch_name}_KEY'
+        # variables don't support hyphens, so replace them with underscores.
+        pkey_varname = f'{branch_name.replace("-", "_")}_KEY'
         secret_envmap[pkey_varname] = pubkey
 
         yaml_file['name'] = branch_name


### PR DESCRIPTION
If the user specified a custom branch name that contained `-` characters for secrets attack, then generated bash script would fail because `-` characters cannot be present in bash variables.

This fix changes all `-` characters to `_` when the script is generated.