### PR TITLE
Improvement: Speed up public organization enumeration

### DIFF
--- a/gato/enumerate/enumerate.py
+++ b/gato/enumerate/enumerate.py
@@ -180,15 +180,12 @@ class Enumerator:
         for wf_query in wf_queries:
             result = self.org_e.api.call_post('/graphql', wf_query)
             self.repo_e.construct_workflow_cache(result.json()['data']['nodes'])
-
-        large_org_enum = len(enum_list) > 100
- 
         for repo in enum_list:
             Output.tabbed(
                 f"Enumerating: {Output.bright(repo.name)}!"
             )
 
-            self.repo_e.enumerate_repository(repo, large_org_enum)
+            self.repo_e.enumerate_repository(repo, large_org_enum=len(enum_list) > 100)
             self.repo_e.enumerate_repository_secrets(repo)
 
             Recommender.print_repo_secrets(

--- a/gato/enumerate/enumerate.py
+++ b/gato/enumerate/enumerate.py
@@ -174,12 +174,16 @@ class Enumerator:
             f"the {organization.name} organization!"
         )
 
-        Output.info(f"Querying and caching workflow yml files!")
+        Output.info(f"Querying and caching workflow YAML files!")
         wf_queries = GqlQueries.get_workflow_ymls(enum_list)
   
         for wf_query in wf_queries:
             result = self.org_e.api.call_post('/graphql', wf_query)
-            self.repo_e.construct_workflow_cache(result.json()['data']['nodes'])
+            # Sometimes we don't get a 200, fall back in this case.
+            if result.status_code == 200:
+                self.repo_e.construct_workflow_cache(result.json()['data']['nodes'])
+            else:
+                Output.warn("GraphQL query failed, will revert to REST workflow query for impacted repositories!")
         for repo in enum_list:
             Output.tabbed(
                 f"Enumerating: {Output.bright(repo.name)}!"

--- a/gato/enumerate/enumerate.py
+++ b/gato/enumerate/enumerate.py
@@ -181,9 +181,8 @@ class Enumerator:
             result = self.org_e.api.call_post('/graphql', wf_query)
             self.repo_e.construct_workflow_cache(result.json()['data']['nodes'])
 
-        if len(enum_list) > 100:
-            large_org_enum = True
-
+        large_org_enum = len(enum_list) > 100
+ 
         for repo in enum_list:
             Output.tabbed(
                 f"Enumerating: {Output.bright(repo.name)}!"

--- a/gato/enumerate/recommender.py
+++ b/gato/enumerate/recommender.py
@@ -140,7 +140,7 @@ class Recommender:
             Output.result(
                 f"The repository contains a workflow: "
                 f"{Output.bright(repository.sh_workflow_names[0])} that "
-                "executes on self-hosted runners!"
+                "might execute on self-hosted runners!"
             )
 
         if repository.accessible_runners:

--- a/gato/enumerate/recommender.py
+++ b/gato/enumerate/recommender.py
@@ -157,6 +157,11 @@ class Recommender:
                 f"{Output.bright(repository.accessible_runners[0].machine_name)}"
             )
 
+            for runner in repository.accessible_runners:
+                if runner.non_ephemeral:
+                    Output.owned("The repository contains a non-ephemeral self-hosted runner!")
+                    break
+
         if repository.runners:
             Output.result(
                 f"The repository has {len(repository.runners)} repo-level"

--- a/gato/enumerate/repository.py
+++ b/gato/enumerate/repository.py
@@ -141,6 +141,8 @@ class RepositoryEnum():
             # more important here and it's ok if it takes time.
             elif not repository.is_public() and self.__perform_runlog_enumeration(repository):
                 runner_detected = True
+            else:
+                runner_detected = self.__perform_runlog_enumeration(repository)
 
         if runner_detected:
             # Only display permissions (beyond having none) if runner is

--- a/gato/enumerate/repository.py
+++ b/gato/enumerate/repository.py
@@ -36,15 +36,16 @@ class RepositoryEnum():
         """
         runner_detected = False
         wf_runs = self.api.retrieve_run_logs(
-            repository.name, short_circuit=True
+            repository.name, short_circuit=False
         )
 
         if wf_runs:
-            runner = Runner(
-                wf_runs[0]['runner_name'], wf_runs[0]['machine_name']
-            )
+            for wf_run in wf_runs:
+                runner = Runner(
+                    wf_run['runner_name'], wf_run['machine_name'], non_ephemeral=wf_run['non_ephemeral']
+                )
 
-            repository.add_accessible_runner(runner)
+                repository.add_accessible_runner(runner)
             runner_detected = True
 
         return runner_detected
@@ -79,7 +80,8 @@ class RepositoryEnum():
             # At this point we only know the extension, so handle and
             #  ignore malformed yml files.
             except Exception as parse_error:
-                print(parse_error)
+
+                print(f"{wf}: {str(parse_error)}")
                 logger.warning("Attmpted to parse invalid yaml!")
 
         return runner_wfs

--- a/gato/enumerate/repository.py
+++ b/gato/enumerate/repository.py
@@ -136,7 +136,10 @@ class RepositoryEnum():
             # the workflow suggests a sh_runner.
             if large_org_enum and runner_detected:
                 self.__perform_runlog_enumeration(repository)
-            elif self.__perform_runlog_enumeration(repository):
+
+            # If we are doing internal enum, get the logs, because coverage is
+            # more important here and it's ok if it takes time.
+            elif not repository.is_public() and self.__perform_runlog_enumeration(repository):
                 runner_detected = True
 
         if runner_detected:

--- a/gato/enumerate/repository.py
+++ b/gato/enumerate/repository.py
@@ -36,7 +36,7 @@ class RepositoryEnum():
         """
         runner_detected = False
         wf_runs = self.api.retrieve_run_logs(
-            repository.name, short_circuit=False
+            repository.name, short_circuit=True
         )
 
         if wf_runs:

--- a/gato/github/__init__.py
+++ b/gato/github/__init__.py
@@ -1,2 +1,3 @@
 from .api import Api
+from .gql_queries import GqlQueries
 from .search import Search

--- a/gato/github/api.py
+++ b/gato/github/api.py
@@ -130,6 +130,11 @@ class Api():
                 if "Set up job" in zipinfo.filename:
                     with runres.open(zipinfo) as run_setup:
                         content = run_setup.read().decode()
+                        if "Image Release: https://github.com/actions/runner-images" in content:
+                            # Larger runners will appear to be self-hosted, but
+                            # they will have the image name. Skip if we see this.
+                            continue
+
                         if "Runner name" in content or \
                                 "Machine name" in content:
 

--- a/gato/github/api.py
+++ b/gato/github/api.py
@@ -637,7 +637,6 @@ class Api():
                         if short_circuit:
                             return run_logs.values()
                 elif run_log.status_code == 410:
-                    print("can't get")
                     break
                 else:
                     logger.debug(

--- a/gato/github/api.py
+++ b/gato/github/api.py
@@ -121,8 +121,6 @@ class Api():
                         content = run_setup.read().decode()
                         if "Cleaning the repository" in content:
                             non_ephemeral = True
-                        else:
-                            non_ephemeral = False
 
                         if log_package:
                             log_package['non_ephemeral'] = non_ephemeral
@@ -616,7 +614,7 @@ class Api():
         Returns:
             list: List of run logs for runs that ran on self-hosted runners.
         """
-        runs = self.call_get(f'/repos/{repo_name}/actions/runs', params={"per_page": "100"})
+        runs = self.call_get(f'/repos/{repo_name}/actions/runs', params={"per_page": "30"})
 
         # This is a dictionary so we can de-duplicate runner IDs based on
         # the machine_name:runner_name.

--- a/gato/github/gql_queries.py
+++ b/gato/github/gql_queries.py
@@ -1,0 +1,54 @@
+from gato.models import Repository
+
+class GqlQueries():
+    """Constructs graphql queries for use with the GitHub GraphQL api.
+    """
+
+    GET_YMLS = """
+        query RepoFiles($node_ids: [ID!]!) {
+        nodes(ids: $node_ids) {
+            ... on Repository {
+            nameWithOwner
+            object(expression: "HEAD:.github/workflows/") {
+                ... on Tree {
+                entries {
+                    name
+                    type
+                    mode
+                    object {
+                    ... on Blob {
+                        byteSize
+                        text
+                    }
+                    }
+                }
+                }
+            }
+            }
+        }
+        }
+    """
+
+    @staticmethod
+    def get_workflow_ymls(repos: list):
+        """Retrieve workflow yml files for ea
+
+        Args:
+            repos (List[Repository]): List of repository objects
+        Returns:
+            (list): List of JSON post parameters for each graphQL query.
+        """
+        queries = []
+
+        for i in range(0, (len(repos) // 100) + 1):
+
+            top_len = len(repos) if len(repos) < (100 + i*100) else (100 + i*100)
+            query = {
+                "query": GqlQueries.GET_YMLS,
+                "variables": {
+                    "node_ids": [repo.repo_data['node_id'] for repo in repos[0+100*i:top_len]]
+                }
+            }
+
+            queries.append(query)
+        return queries

--- a/gato/models/runner.py
+++ b/gato/models/runner.py
@@ -11,7 +11,8 @@ class Runner:
             machine_name=None,
             os=None,
             status=None,
-            labels=[]):
+            labels=[],
+            non_ephemeral=False):
         """Constructor for runner wrapper object.
 
         Args:
@@ -27,6 +28,7 @@ class Runner:
         self.os = os
         self.status = status
         self.labels = labels
+        self.non_ephemeral = non_ephemeral
 
     def toJSON(self):
         """Converts the repository to a Gato JSON representation.
@@ -37,7 +39,8 @@ class Runner:
             else "Unknown",
             "os": self.os if self.os else "Unknown",
             "status": self.status if self.status else "Unknown",
-            "labels": [label for label in self.labels]
+            "labels": [label for label in self.labels],
+            "non_ephemeral": self.non_ephemeral
         }
 
         return representation

--- a/gato/workflow_parser/workflow_parser.py
+++ b/gato/workflow_parser/workflow_parser.py
@@ -104,7 +104,16 @@ class WorkflowParser():
                         matrix = job_details['strategy']['matrix']
 
                         # Use previously acquired key to retrieve list of OSes
-                        os_list = matrix[matrix_key]
+                        if matrix_key in matrix:
+                            os_list = matrix[matrix_key]
+                        elif 'include' in matrix:
+                            inclusions = matrix['include']
+                            os_list = []
+                            for inclusion in inclusions:
+                                if matrix_key in inclusion:
+                                    os_list.append(inclusion[matrix_key])
+                        else:
+                            continue
 
                         # We only need ONE to be self hosted, others can be
                         # GitHub hosted

--- a/gato/workflow_parser/workflow_parser.py
+++ b/gato/workflow_parser/workflow_parser.py
@@ -71,10 +71,6 @@ class WorkflowParser():
                 dirpath, f'{self.repo_name}/{self.wf_name}'), 'w') as wf_out:
             wf_out.write(self.raw_yaml)
             return True
-    
-    def get_secrets(self):
-        """_summary_
-        """
 
     def self_hosted(self):
         """Analyze if any jobs within the workflow utilize self-hosted runners.

--- a/gato/workflow_parser/workflow_parser.py
+++ b/gato/workflow_parser/workflow_parser.py
@@ -93,7 +93,12 @@ class WorkflowParser():
                 elif 'matrix.' in runs_on:
                     # We need to check each OS in the matrix strategy.
                     # Extract the matrix key from the variable
-                    matrix_key = re.search(self.MATRIX_KEY_EXTRACTION_REGEX, runs_on).group(1)
+                    matrix_match = re.search(self.MATRIX_KEY_EXTRACTION_REGEX, runs_on)
+
+                    if matrix_match:
+                        matrix_key = matrix_match.group(1)
+                    else:
+                        continue
                     # Check if strategy exists in the yaml file
                     if 'strategy' in job_details and 'matrix' in job_details['strategy']:
                         matrix = job_details['strategy']['matrix']

--- a/gato/workflow_parser/workflow_parser.py
+++ b/gato/workflow_parser/workflow_parser.py
@@ -68,6 +68,10 @@ class WorkflowParser():
                 dirpath, f'{self.repo_name}/{self.wf_name}'), 'w') as wf_out:
             wf_out.write(self.raw_yaml)
             return True
+    
+    def get_secrets(self):
+        """_summary_
+        """
 
     def self_hosted(self):
         """Analyze if any jobs within the workflow utilize self-hosted runners.
@@ -76,8 +80,10 @@ class WorkflowParser():
            list: List of jobs within the workflow that utilize self-hosted
            runners.
         """
-
         sh_jobs = []
+        if 'jobs' not in self.parsed_yml:
+            return sh_jobs
+
         for jobname, job_details in self.parsed_yml['jobs'].items():
             if 'runs-on' in job_details:
                 runs_on = job_details['runs-on']

--- a/gato/workflow_parser/workflow_parser.py
+++ b/gato/workflow_parser/workflow_parser.py
@@ -109,9 +109,10 @@ class WorkflowParser():
                         # We only need ONE to be self hosted, others can be
                         # GitHub hosted
                         for key in os_list:
-                            if key not in self.GITHUB_HOSTED_LABELS and not re.match(self.LARGER_RUNNER_REGEX_LIST, key):
-                                sh_jobs.append((jobname, job_details))
-                                break
+                            if type(key) == str:
+                                if key not in self.GITHUB_HOSTED_LABELS and not re.match(self.LARGER_RUNNER_REGEX_LIST, key):
+                                    sh_jobs.append((jobname, job_details))
+                                    break
                     pass
                 else:
                     if type(runs_on) == list:

--- a/gato/workflow_parser/workflow_parser.py
+++ b/gato/workflow_parser/workflow_parser.py
@@ -28,6 +28,9 @@ class WorkflowParser():
         'windows-2022',
         'windows-2019',
         'windows-2016', # deprecated, but we don't want false positives on older repos.
+        'macOS-13',
+        'macOS-12',
+        'macOS-11',
         'macos-11',
         'macos-12',
         'macos-13',

--- a/test/test_cases.json
+++ b/test/test_cases.json
@@ -119,7 +119,7 @@
                 "type": "stdout"
             },
             {
-                "expect": "[+] The repository contains a workflow: main.yml that executes on self-hosted runners!",
+                "expect": "[+] The repository contains a workflow: main.yml that might execute on self-hosted runners!",
                 "type": "stdout"
             }
         ],

--- a/unit_test/test_api.py
+++ b/unit_test/test_api.py
@@ -456,7 +456,7 @@ def test_retrieve_run_logs(mock_get):
 
     mock_get.return_value.json.return_value = {
         "workflow_runs": [
-            {"id": 123, "run_attempt": 1}
+            {"id": 123, "run_attempt": 1, "conclusion": "success", "head_branch": "dev", "path": ".github/workflows/build.yml@dev"}
         ]
     }
 

--- a/unit_test/test_api.py
+++ b/unit_test/test_api.py
@@ -469,14 +469,14 @@ def test_retrieve_run_logs(mock_get):
     logs = abstraction_layer.retrieve_run_logs("testOrg/testRepo")
 
     assert len(logs) == 1
-    assert logs[0]['runner_name'] == 'ghrunner-test'
+    assert list(logs)[0]['runner_name'] == 'ghrunner-test'
 
     logs = abstraction_layer.retrieve_run_logs(
         "testOrg/testRepo", short_circuit=False
     )
 
     assert len(logs) == 1
-    assert logs[0]['runner_name'] == 'ghrunner-test'
+    assert list(logs)[0]['runner_name'] == 'ghrunner-test'
 
 
 @patch("gato.github.api.requests.get")

--- a/unit_test/test_enumerate.py
+++ b/unit_test/test_enumerate.py
@@ -103,7 +103,7 @@ def test_enumerate_repo_admin(mock_api, capsys):
     }
 
     mock_api.return_value.retrieve_run_logs.return_value = [
-        {"machine_name": "unittest1", "runner_name": "much_unit_such_test"}
+        {"machine_name": "unittest1", "runner_name": "much_unit_such_test", "non_ephemeral": False}
     ]
 
     repo_data = json.loads(json.dumps(TEST_REPO_DATA))
@@ -143,7 +143,7 @@ def test_enumerate_repo_admin_no_wf(mock_api, capsys):
     }
 
     mock_api.return_value.retrieve_run_logs.return_value = [
-        {"machine_name": "unittest1", "runner_name": "much_unit_such_test"}
+        {"machine_name": "unittest1", "runner_name": "much_unit_such_test", "non_ephemeral": False}
     ]
 
     repo_data = json.loads(json.dumps(TEST_REPO_DATA))
@@ -183,7 +183,7 @@ def test_enumerate_repo_no_wf_no_admin(mock_api, capsys):
     }
 
     mock_api.return_value.retrieve_run_logs.return_value = [
-        {"machine_name": "unittest1", "runner_name": "much_unit_such_test"}
+        {"machine_name": "unittest1", "runner_name": "much_unit_such_test", "non_ephemeral": False}
     ]
 
     repo_data = json.loads(json.dumps(TEST_REPO_DATA))
@@ -222,7 +222,7 @@ def test_enumerate_repo_no_wf_maintain(mock_api, capsys):
     }
 
     mock_api.return_value.retrieve_run_logs.return_value = [
-        {"machine_name": "unittest1", "runner_name": "much_unit_such_test"}
+        {"machine_name": "unittest1", "runner_name": "much_unit_such_test", "non_ephemeral": False}
     ]
 
     repo_data = json.loads(json.dumps(TEST_REPO_DATA))
@@ -262,7 +262,7 @@ def test_enumerate_repo_only(mock_api, capsys):
     }
 
     mock_api.return_value.retrieve_run_logs.return_value = [
-        {"machine_name": "unittest1", "runner_name": "much_unit_such_test"}
+        {"machine_name": "unittest1", "runner_name": "much_unit_such_test", "non_ephemeral": False}
     ]
 
     repo_data = json.loads(json.dumps(TEST_REPO_DATA))

--- a/unit_test/test_repo_enumerate.py
+++ b/unit_test/test_repo_enumerate.py
@@ -45,7 +45,7 @@ def test_enumerate_repo():
     }
 
     mock_api.retrieve_run_logs.return_value = [
-        {"machine_name": "unittest1", "runner_name": "much_unit_such_test"}
+        {"machine_name": "unittest1", "runner_name": "much_unit_such_test", "non_ephemeral": False}
     ]
 
     repo_data = json.loads(json.dumps(TEST_REPO_DATA))
@@ -75,7 +75,7 @@ def test_enumerate_repo_admin():
     }
 
     mock_api.retrieve_run_logs.return_value = [
-        {"machine_name": "unittest1", "runner_name": "much_unit_such_test"}
+        {"machine_name": "unittest1", "runner_name": "much_unit_such_test", "non_ephemeral": False}
     ]
 
     repo_data = json.loads(json.dumps(TEST_REPO_DATA))


### PR DESCRIPTION
This PR addresses the core problems highlighted in https://github.com/praetorian-inc/gato/issues/44

For large public organization enum, Gato will now only perform run log analysis if repositories pass a heuristic based on workflow analysis. Additionally, Gato will use the GraphQL API to download all workflow ymls and cache them before enumerating individual repositories.

Additionally, Gato will be more selective with the run logs it downloads to avoid downloading duplicate logs for the same workflow file and trigger. Furthermore, I've added a new heuristic that will determine whether a self-hosted runner is ephemeral. The heuristic works by looking for the clean repository step in the output for `actions/checkout`. Note, this is a **heuristic**, and it may be subject to false positives (rare, but possible in limited scenarios with caching), or false negatives (more likely).

With these changes, you can run Gato against a large organization like Microsoft within a reasonable time. This supports continuous testing and monitoring use cases as more organizations become aware of the dangers of self-hosted runner misconfigurations.