### PR TITLE
Add SourceGraph search feature.

### DIFF
--- a/gato/cli/cli.py
+++ b/gato/cli/cli.py
@@ -293,13 +293,18 @@ def search(args, parser):
             parser.error(
                 f"{Fore.RED}[-]{Style.RESET_ALL} You must select an organization "
                 "or pass a custom query!."
-        )
+            )
         if args.query:
             gh_search_runner.use_search_api(
-                organization=args.target, query=args.query
+                organization=args.target,
+                query=args.query,
+                output_text=args.output_text
             )
         else:
-            gh_search_runner.use_search_api(organization=args.target)
+            gh_search_runner.use_search_api(
+                organization=args.target,
+                output_text=args.output_text
+            )
 
 
 def configure_parser_general(parser):

--- a/gato/cli/cli.py
+++ b/gato/cli/cli.py
@@ -276,19 +276,30 @@ def search(args, parser):
         http_proxy=args.http_proxy,
         github_url=args.api_url
     )
+    if args.sourcegraph:
+        if args.query and args.target:
+            parser.error(
+                f"{Fore.RED}[-]{Style.RESET_ALL} You cannot select an organization "
+                "with a custom query!"
+            )
 
-    if not (args.query or args.target):
-        parser.error(
-            f"{Fore.RED}[-]{Style.RESET_ALL} You must select an organization "
-            "or pass a custom query!."
-        )
-
-    if args.query:
-        gh_search_runner.use_search_api(
-            organization=args.target, query=args.query
+        gh_search_runner.use_sourcegraph_api(
+            organization=args.target,
+            query=args.query,
+            output_text=args.output_text
         )
     else:
-        gh_search_runner.use_search_api(organization=args.target)
+        if not (args.query or args.target):
+            parser.error(
+                f"{Fore.RED}[-]{Style.RESET_ALL} You must select an organization "
+                "or pass a custom query!."
+        )
+        if args.query:
+            gh_search_runner.use_search_api(
+                organization=args.target, query=args.query
+            )
+        else:
+            gh_search_runner.use_search_api(organization=args.target)
 
 
 def configure_parser_general(parser):
@@ -562,4 +573,20 @@ def configure_parser_search(parser):
         help="Pass a custom query to GitHub code search",
         metavar="QUERY",
         required=False
+    )
+
+    parser.add_argument(
+        "--sourcegraph", "-sg",
+        help="Use Sourcegraph API to search for self-hosted runners.",
+        required=False,
+        action="store_true"
+    )
+
+    parser.add_argument(
+        "--output-text", "-oT",
+        help=(
+            "Save enumeration output to text file."
+        ),
+        metavar="TEXT_FILE",
+        type=StringType(256)
     )

--- a/gato/cli/cli.py
+++ b/gato/cli/cli.py
@@ -283,10 +283,9 @@ def search(args, parser):
                 "with a custom query!"
             )
 
-        gh_search_runner.use_sourcegraph_api(
+        results = gh_search_runner.use_sourcegraph_api(
             organization=args.target,
-            query=args.query,
-            output_text=args.output_text
+            query=args.query
         )
     else:
         if not (args.query or args.target):
@@ -295,16 +294,17 @@ def search(args, parser):
                 "or pass a custom query!."
             )
         if args.query:
-            gh_search_runner.use_search_api(
+            results = gh_search_runner.use_search_api(
                 organization=args.target,
-                query=args.query,
-                output_text=args.output_text
+                query=args.query
             )
         else:
-            gh_search_runner.use_search_api(
-                organization=args.target,
-                output_text=args.output_text
+            results = gh_search_runner.use_search_api(
+                organization=args.target
             )
+
+    if results:
+        gh_search_runner.present_results(results, args.output_text)
 
 
 def configure_parser_general(parser):

--- a/gato/github/search.py
+++ b/gato/github/search.py
@@ -46,7 +46,7 @@ class Search():
         if custom_query:
             query['q'] = custom_query
         else:
-            query['q'] = f'self-hosted org:{organization} language:yaml path:.github/workflows',
+            query['q'] = f'self-hosted org:{organization} language:yaml path:.github/workflows'
 
         next_page = f"/search/code?q={query['q']}&sort={query['sort']}" \
                     f"&per_page={query['per_page']}&page={query['page']}"

--- a/gato/search/search.py
+++ b/gato/search/search.py
@@ -64,13 +64,18 @@ class Searcher:
             organization: str,
             query=None,
             output_text=None):
-        """Use Sourcegraph API to identify repositories that might use 
-        self hosted runners at GitHub scale.
+        """
+        This method is used to search for repositories in an organization using the Sourcegraph API.
+        It constructs a search query and sends a GET request to the Sourcegraph search API.
+        The results are streamed and added to a set.
 
         Args:
-            organization (str, optional): Organization to filter on.
-            query (str, optional): Custom query to use.
-            output_text(str, optional): Path to output text file.
+            organization (str): The name of the organization to search in.
+            query (str, optional): A custom search query. If not provided, a default query is used.
+            output_text (str, optional): The file path where the results should be written. Defaults to None.
+
+        Returns:
+            set: A set of search results.
         """
         repo_filter = f"repo:{organization}/ " if organization else ""
         url = "https://sourcegraph.com/.api/search/stream"

--- a/gato/search/search.py
+++ b/gato/search/search.py
@@ -72,7 +72,6 @@ class Searcher:
         Args:
             organization (str): The name of the organization to search in.
             query (str, optional): A custom search query. If not provided, a default query is used.
-            output_text (str, optional): The file path where the results should be written. Defaults to None.
 
         Returns:
             set: A set of search results.
@@ -114,19 +113,9 @@ class Searcher:
                                 element["repository"].replace("github.com/", "")
                             )
 
-        Output.result(
-            f"Identified {len(results)} non-fork repositories that matched "
-            "the criteria!"
-        )
-        if output_text:
-            with open(output_text, "w") as file_output:
-                for candidate in results:
-                    file_output.write(f"{candidate}\n")
+        return results
 
-        for candidate in results:
-            Output.tabbed(candidate)
-
-    def use_search_api(self, organization: str, query=None, output_text=None):
+    def use_search_api(self, organization: str, query=None):
         """Utilize GitHub Code Search API to try and identify repositories
         using self-hosted runners. This is subject to a high false-positive
         rate because any occurance of 'self-hosted' within a YAML file will
@@ -138,7 +127,6 @@ class Searcher:
             organization (str): Organization to enumerate using
             the GitHub code search API.
             query (str, optional): Custom code-search query.
-            output_text(str, optional): Path to output text file.
 
         Returns:
             list: List of repositories suspected of using self-hosted runners
@@ -165,18 +153,7 @@ class Searcher:
             organization, custom_query=query
         )
 
-        Output.result(
-            f"Identified {len(candidates)} non-fork repositories that matched "
-            "the criteria!"
-        )
-
-        if output_text:
-            with open(output_text, "w") as file_output:
-                for candidate in candidates:
-                    file_output.write(f"{candidate}\n")
-
-        for candidate in candidates:
-            Output.tabbed(candidate)
+        return candidates
 
     def present_results(self, results, output_text=None):
         """


### PR DESCRIPTION
Also addresses #52.

Adds a new `--sourcegraph` flag to the search module to use Sourcegraph's public code search API instead of GitHub code search. Sourcegraph supports regular expressions in queries via the API while GitHub's API has problems with complex regular expressions.

Additionally, I added an `--output-text` flag that will write the results to a text file. This can be passed directly into Gato's enumeration mode.

Example:

```
gato search --target microsoft -sg -oT ms_selfHosted.txt
gato enumerate -R ms_selfHosted.txt
```