### PR TITLE
Fix false negative issue with ephemeral runner check

### DIFF
--- a/gato/github/api.py
+++ b/gato/github/api.py
@@ -118,7 +118,7 @@ class Api():
         with zipfile.ZipFile(io.BytesIO(log_content)) as runres:
             for zipinfo in runres.infolist():
                 # TODO use a lambda for this messy logic
-                if "Run actionscheckout" in zipinfo.filename:
+                if "checkout" in zipinfo.filename or "Checkout" in zipinfo.filename:
                     with runres.open(zipinfo) as run_setup:
                         content = run_setup.read().decode()
                         if "Cleaning the repository" in content:


### PR DESCRIPTION
Currently, the ephemeral runner check will miss some cases of the clean repository step. This makes the file name check less restrictive, so it looks in more of the run log.