### PR TITLE
Capture additional metadata from runlogs 

### DIFF
--- a/gato/enumerate/recommender.py
+++ b/gato/enumerate/recommender.py
@@ -155,6 +155,11 @@ class Recommender:
                 f"{Output.bright(repository.accessible_runners[0].runner_name)}"
                 f" and the machine name was "
                 f"{Output.bright(repository.accessible_runners[0].machine_name)}"
+                f" and the runner type was "
+                f"{Output.bright(repository.accessible_runners[0].runner_type)}"
+                f" in the {Output.bright(repository.accessible_runners[0].runner_group)} group"
+                f" with the following labels: "
+                f"{Output.bright(', '.join(repository.accessible_runners[0].labels))}"
             )
 
             for runner in repository.accessible_runners:

--- a/gato/enumerate/repository.py
+++ b/gato/enumerate/repository.py
@@ -43,7 +43,13 @@ class RepositoryEnum():
         if wf_runs:
             for wf_run in wf_runs:
                 runner = Runner(
-                    wf_run['runner_name'], wf_run['machine_name'], non_ephemeral=wf_run['non_ephemeral']
+                    wf_run['runner_name'],
+                    wf_run['runner_type'],
+                    wf_run['token_permissions'],
+                    runner_group=wf_run['runner_group'],
+                    machine_name=wf_run['machine_name'],
+                    labels=wf_run['requested_labels'],
+                    non_ephemeral=wf_run['non_ephemeral']
                 )
 
                 repository.add_accessible_runner(runner)
@@ -132,17 +138,7 @@ class RepositoryEnum():
             runner_detected = True
 
         if not self.skip_log:
-            # If we are enumerating an organization, only enumerate runlogs if
-            # the workflow suggests a sh_runner.
-            if large_org_enum and runner_detected:
-                self.__perform_runlog_enumeration(repository)
-
-            # If we are doing internal enum, get the logs, because coverage is
-            # more important here and it's ok if it takes time.
-            elif not repository.is_public() and self.__perform_runlog_enumeration(repository):
-                runner_detected = True
-            else:
-                runner_detected = self.__perform_runlog_enumeration(repository)
+            runner_detected = self.__perform_runlog_enumeration(repository)
 
         if runner_detected:
             # Only display permissions (beyond having none) if runner is

--- a/gato/models/runner.py
+++ b/gato/models/runner.py
@@ -8,6 +8,9 @@ class Runner:
     def __init__(
             self,
             runner_name,
+            runner_type,
+            token_permissions,
+            runner_group=None,
             machine_name=None,
             os=None,
             status=None,
@@ -25,6 +28,9 @@ class Runner:
         """
         self.runner_name = runner_name
         self.machine_name = machine_name
+        self.runner_group = runner_group
+        self.runner_type = runner_type
+        self.token_permissions = token_permissions
         self.os = os
         self.status = status
         self.labels = labels
@@ -37,6 +43,9 @@ class Runner:
             "name": self.runner_name,
             "machine_name": self.machine_name if self.machine_name
             else "Unknown",
+            "runner_type": self.runner_type if self.runner_type else "Unknown",
+            "runner_group_name": self.runner_group if self.runner_group else "Unknown",
+            "token_permissions": self.token_permissions,
             "os": self.os if self.os else "Unknown",
             "status": self.status if self.status else "Unknown",
             "labels": [label for label in self.labels],

--- a/gato/models/runner.py
+++ b/gato/models/runner.py
@@ -8,8 +8,8 @@ class Runner:
     def __init__(
             self,
             runner_name,
-            runner_type,
-            token_permissions,
+            runner_type=None,
+            token_permissions=None,
             runner_group=None,
             machine_name=None,
             os=None,


### PR DESCRIPTION
Made some changes to capture additional metadata from the runlogs, including: 
 - Runner group
 - Requested labels
 - Runner type 
 - GitHub token permissions 

had to update the logic to parse files since we must parse the `0_buildname` file instead of just the `Set up job.txt` file. 

Additionally, found an issue where self.__perform_runlog_enumeration was being executed twice so made some changes to `repository.py` to help speed things up. Let me know what you think! 