### PR TITLE
Hotfix: Reduce false positives

### DIFF
--- a/gato/github/api.py
+++ b/gato/github/api.py
@@ -131,7 +131,8 @@ class Api():
                         content_lines = content.split('\n')
 
                         if "Image Release: https://github.com/actions/runner-images" in content \
-                                or "Job is about to start running on the hosted runner: GitHub Actions" in content:
+                                or "Job is about to start running on the hosted runner: GitHub Actions" in content \
+                                or "Job is cancelled before starting" in content:
                             # Larger runners will appear to be self-hosted, but
                             # they will have the image name. Skip if we see this.
                             # If the log contains "job is about to start running on hosted runner",
@@ -684,7 +685,7 @@ class Api():
 
         return None
 
-    def retrieve_run_logs(self, repo_name: str, short_circuit: str = True):
+    def retrieve_run_logs(self, repo_name: str, short_circuit: bool = True):
         """Retrieve the most recent run log associated with a repository.
 
         Args:

--- a/gato/workflow_parser/workflow_parser.py
+++ b/gato/workflow_parser/workflow_parser.py
@@ -28,7 +28,7 @@ class WorkflowParser():
         'windows-2022',
         'windows-2019',
         'windows-2016',  # deprecated, but we don't want false positives on older repos.
-        'macOS-14'
+        'macOS-14',
         'macOS-13',
         'macOS-12',
         'macOS-11',

--- a/gato/workflow_parser/workflow_parser.py
+++ b/gato/workflow_parser/workflow_parser.py
@@ -28,6 +28,7 @@ class WorkflowParser():
         'windows-2022',
         'windows-2019',
         'windows-2016',  # deprecated, but we don't want false positives on older repos.
+        'macOS-14'
         'macOS-13',
         'macOS-12',
         'macOS-11',
@@ -35,7 +36,7 @@ class WorkflowParser():
         'macos-12',
         'macos-13',
         'macos-13-xl',
-        'macos-12',
+        'macos-14',
     ]
 
     LARGER_RUNNER_REGEX_LIST = r'(windows|ubuntu)-(22.04|20.04|2019-2022)-(4|8|16|32|64)core-(16|32|64|128|256)gb'


### PR DESCRIPTION
This removes a false positive where a job is cancelled before getting picked up by a runner. This was not handled previously and would result in a "self-hosted" runner identified, even on common GitHub-hosted labels.

Also fixed a typo where macos-14 was missing from labels.