### PR TITLE
Hotfix: ignore invalid ymls

### DIFF
--- a/gato/enumerate/repository.py
+++ b/gato/enumerate/repository.py
@@ -77,6 +77,8 @@ class RepositoryEnum():
         for (wf, yml) in ymls:
             try:
                 parsed_yml = WorkflowParser(yml, repository.name, wf)
+                if not parsed_yml:
+                    continue
                 self_hosted_jobs = parsed_yml.self_hosted()
 
                 if self_hosted_jobs:

--- a/gato/workflow_parser/workflow_parser.py
+++ b/gato/workflow_parser/workflow_parser.py
@@ -81,7 +81,7 @@ class WorkflowParser():
            runners.
         """
         sh_jobs = []
-        if 'jobs' not in self.parsed_yml:
+        if not self.parsed_yml or 'jobs' not in self.parsed_yml:
             return sh_jobs
 
         for jobname, job_details in self.parsed_yml['jobs'].items():


### PR DESCRIPTION
Invalid or incomplete YMLs that still partially parse break the parser. We need to handle these more gracefully.