### PR TITLE
Hotfix: Ignores workflow logs in an abnormal state

### DIFF
--- a/gato/github/api.py
+++ b/gato/github/api.py
@@ -132,12 +132,14 @@ class Api():
 
                         if "Image Release: https://github.com/actions/runner-images" in content \
                                 or "Job is about to start running on the hosted runner: GitHub Actions" in content \
-                                or "Job is cancelled before starting" in content:
+                                or "Job is cancelled before starting" in content \
+                                or "Job is about to start" in content_lines[-2]:
                             # Larger runners will appear to be self-hosted, but
                             # they will have the image name. Skip if we see this.
                             # If the log contains "job is about to start running on hosted runner",
                             # the runner is a Github hosted runner so we can skip it.
                             continue
+
                         index = 0
                         while index < len(content_lines) and content_lines[index]:
                             line = content_lines[index]


### PR DESCRIPTION
Sometimes workflows "fail" but the logs are incomplete, causing Gato to run into some parsing issues. Just ignore these.

An example action run is https://github.com/Azure/terraform-azurerm-network-security-group/actions/runs/8768591045