### PR TITLE
Feature: Add public or private status of a repo to json output

### DIFF
--- a/gato/models/repository.py
+++ b/gato/models/repository.py
@@ -103,6 +103,7 @@ class Repository():
         """
         representation = {
             "name": self.name,
+            "private": self.is_private(),
             "enum_time": self.enum_time.ctime(),
             "permissions": self.permission_data,
             "can_fork": self.can_fork(),


### PR DESCRIPTION
This addition adds a "private" boolean value to the json output depending on whether the repo is private or public