### PR TITLE
Migrate MacOS Unit Tests to ARM-supported Python

### DIFF
--- a/.github/workflows/pytest.yaml
+++ b/.github/workflows/pytest.yaml
@@ -1,5 +1,5 @@
 name: Test and Lint
-on: 
+on:
     push:
     pull_request:
 
@@ -38,7 +38,7 @@ jobs:
         runs-on: macos-latest
         strategy:
           matrix:
-            python-version: ["3.7", "3.8", "3.9", "3.10"]
+            python-version: ["3.11", "3.12"]
 
         timeout-minutes: 10
 


### PR DESCRIPTION
GHA runners for MacOS are using ARM now. Some of the older versions of python don't have ARM images, so we need to use the newer versions.

Closes #75 