### PR TITLE
for newer git version

### DIFF
--- a/gato/cli/cli.py
+++ b/gato/cli/cli.py
@@ -123,6 +123,8 @@ def validate_git_config(parser):
     git_version = git.version_check()
 
     if git_version:
+        git_version = git_version.split('.')[0:3]  # Keep only the first three parts
+        git_version = '.'.join(git_version)   
         git_version = version.parse(git_version)
         if git_version < version.parse(REQUIRED_GIT_VERSION):
             parser.error(


### PR DESCRIPTION
We get an error while running the git versions like mentioned in the error message below
packaging.version.InvalidVersion: Invalid version: '2.45.2.windows.1