### PR TITLE
fix bug in path parsing during false positive reduction

### DIFF
--- a/gato/artifact_secrets_scanner/noseyparker.py
+++ b/gato/artifact_secrets_scanner/noseyparker.py
@@ -97,18 +97,20 @@ class NPHandler:
                                               "example", "anon", "passwd",
                                               "pwd", "secretsmanager",
                                               "secret_config"]
+                                
 
                                 if any(exclusion in snippet for exclusion in exclusions):
                                     add_finding = False
                                     continue
 
                                 # Excluding api keys in js files as these are commonly false positives
+                                path = match.get('provenance', [{}])[0].get('path', 'Unknown')
                                 if (finding['rule_name'] == "Generic API Key"
-                                        and ".js" in match["path"]) \
-                                        or "README.md" in match["path"]:
+                                        and ".js" in path) \
+                                        or "README.md" in path:
                                     add_finding = False
-                                    continue
 
+                                    continue
                             Output.tabbed(f"Match: {snippet}")
                             newmatch["snippet"] = snippet
 
@@ -117,7 +119,6 @@ class NPHandler:
                             Output.tabbed(f"Path: {match.get('provenance', [{}])[0].get('path', 'Unknown')}")
                             newmatch["provenance"] = match.get('provenance', [{}])[0].get('path', 'Unknown')
                         Output.tabbed("---")
-
                         np_finding.matches.append(newmatch)
 
                     if add_finding:

--- a/gato/artifact_secrets_scanner/noseyparker.py
+++ b/gato/artifact_secrets_scanner/noseyparker.py
@@ -97,7 +97,6 @@ class NPHandler:
                                               "example", "anon", "passwd",
                                               "pwd", "secretsmanager",
                                               "secret_config"]
-                                
 
                                 if any(exclusion in snippet for exclusion in exclusions):
                                     add_finding = False
@@ -109,15 +108,17 @@ class NPHandler:
                                         and ".js" in path) \
                                         or "README.md" in path:
                                     add_finding = False
-
                                     continue
+
                             Output.tabbed(f"Match: {snippet}")
                             newmatch["snippet"] = snippet
 
                             self.repository.artifact_snippets.add(snippet)
+
                         if 'provenance' in match:
                             Output.tabbed(f"Path: {match.get('provenance', [{}])[0].get('path', 'Unknown')}")
                             newmatch["provenance"] = match.get('provenance', [{}])[0].get('path', 'Unknown')
+
                         Output.tabbed("---")
                         np_finding.matches.append(newmatch)
 


### PR DESCRIPTION
There was an error in the false positive reduction process where it was trying to read a field that did not exist. this PR corrects that