### PR TITLE
Add Branch Protection Enumeration

### DIFF
--- a/gato/enumerate/enumerate.py
+++ b/gato/enumerate/enumerate.py
@@ -251,10 +251,8 @@ class Enumerator:
             self.repo_e.enumerate_repository_secrets(repo)
             self.repo_e.enumerate_branch_protections(repo)
 
-
             if self.wf_artifacts_enum:
                 self.repo_e.enumerate_workflow_artifacts(repo, self.include_all_artifact_secrets)
-
 
             Recommender.print_repo_secrets(
                 self.user_perms['scopes'],
@@ -296,7 +294,6 @@ class Enumerator:
 
             if self.wf_artifacts_enum:
                 self.repo_e.enumerate_workflow_artifacts(repo, self.include_all_artifact_secrets)
-
 
             Recommender.print_repo_secrets(
                 self.user_perms['scopes'],

--- a/gato/enumerate/enumerate.py
+++ b/gato/enumerate/enumerate.py
@@ -249,9 +249,12 @@ class Enumerator:
 
             self.repo_e.enumerate_repository(repo, large_org_enum=len(enum_list) > 100)
             self.repo_e.enumerate_repository_secrets(repo)
+            self.repo_e.enumerate_branch_protections(repo)
+
 
             if self.wf_artifacts_enum:
                 self.repo_e.enumerate_workflow_artifacts(repo, self.include_all_artifact_secrets)
+
 
             Recommender.print_repo_secrets(
                 self.user_perms['scopes'],
@@ -289,9 +292,11 @@ class Enumerator:
             )
             self.repo_e.enumerate_repository(repo)
             self.repo_e.enumerate_repository_secrets(repo)
+            self.repo_e.enumerate_branch_protections(repo)
 
             if self.wf_artifacts_enum:
                 self.repo_e.enumerate_workflow_artifacts(repo, self.include_all_artifact_secrets)
+
 
             Recommender.print_repo_secrets(
                 self.user_perms['scopes'],

--- a/gato/models/repository.py
+++ b/gato/models/repository.py
@@ -26,6 +26,8 @@ class Repository():
         self.org_secrets: List[Secret] = []
         self.sh_workflow_names = []
         self.enum_time = datetime.datetime.now()
+        self.default_branch = ""
+        self.default_branch_protection = None
 
         self.permission_data = self.repo_data['permissions']
         self.sh_runner_access = False
@@ -72,6 +74,10 @@ class Repository():
         """
         self.org_secrets = secrets
 
+    def set_default_branch_protection(self, protections: List):
+        self.default_branch = protections[0]
+        self.default_branch_protection = protections[1]
+
     def set_secrets(self, secrets: List[Secret]):
         """Sets secrets that are attached to this repository.
 
@@ -107,6 +113,8 @@ class Repository():
         representation = {
             "name": self.name,
             "private": self.is_private(),
+            "default_branch": self.default_branch,
+            "default_branch_protection": self.default_branch_protection,
             "enum_time": self.enum_time.ctime(),
             "permissions": self.permission_data,
             "can_fork": self.can_fork(),

--- a/gato/models/repository.py
+++ b/gato/models/repository.py
@@ -74,9 +74,9 @@ class Repository():
         """
         self.org_secrets = secrets
 
-    def set_default_branch_protection(self, protections: List):
-        self.default_branch = protections[0]
-        self.default_branch_protection = protections[1]
+    def set_default_branch_protection(self, branch: str, protection: str):
+        self.default_branch = branch
+        self.default_branch_protection = protection
 
     def set_secrets(self, secrets: List[Secret]):
         """Sets secrets that are attached to this repository.


### PR DESCRIPTION
Gato needs the ability to enumerate branch protections (#96). This PR adds branch protection enumeration by default. It first gets the default branch from the repos info, which we are already collecting. Then it retrieves information about that specific branch.

The total overhead is one additional API call per repository. Only read access to the target repo is required.