### PR TITLE
Add support for using gh app installation tokens during enum

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,7 @@ These constraints were optimized such that the Actions Artifacts Secrets Scanner
 - Option to disable sleep
 - Differentates between public and private repos in output
 - Several bug fixes
+- Enumerate support for GitHub App Installation tokens
 
 ## Who is it for?
 
@@ -125,7 +126,7 @@ parameters for each of the tool's modules by running the following:
 * `gato enum -h`
 * `gato attack -h`
 
-The tool requires a GitHub classic PAT in order to function. To create one, log
+The tool requires a GitHub classic  or app installation token in order to function. To create one, log
 in to GitHub and go to [GitHub Developer
 Settings](https://github.com/settings/tokens) 
 and select `Generate New Token` and then `Generate new token (classic)`.
@@ -134,6 +135,8 @@ After creating this token set the `GH_TOKEN` environment variable within your
 shell by running `export GH_TOKEN=<YOUR_CREATED_TOKEN>`. Alternatively, store 
 the token within a secure password manager and enter it when the application 
 prompts you.
+
+If creating a GitHub App Installation token, the app needs to have at least `Actions:read` and `Contents:read`ß to execute the enumeration modules.
 
 For troubleshooting and additional details, such as installing in developer 
 mode or running unit tests, please see the [wiki](https://github.com/praetorian-inc/gato/wiki).

--- a/README.md
+++ b/README.md
@@ -7,46 +7,69 @@
 </p>
 
 
-Gato, or GitHub Attack Toolkit, is an enumeration and attack tool that allows both 
-blue teamers and offensive security practitioners to identify and exploit 
-pipeline vulnerabilities within a GitHub organization's public and private 
+Gato, or GitHub Attack Toolkit, is an enumeration and attack tool that allows
+both blue teamers and offensive security practitioners to identify and exploit
+pipeline vulnerabilities within a GitHub organization's public and private
 repositories.
 
 The tool has post-exploitation features to leverage a compromised personal
 access token in addition to enumeration features to identify poisoned pipeline
-execution vulnerabilities and actions artifacts secrets against public repositories.
+execution vulnerabilities and actions artifacts secrets against public
+repositories.
 
-GitHub recommends that self-hosted runners only be utilized for private repositories, however, there are thousands of organizations that utilize self-hosted runners. Default configurations are often vulnerable, and Gato uses a mix of workflow file analysis and run-log analysis to identify potentially vulnerable repositories at scale.
+GitHub recommends that self-hosted runners only be utilized for private
+repositories, however, there are thousands of organizations that utilize
+self-hosted runners. Default configurations are often vulnerable, and Gato uses
+a mix of workflow file analysis and run-log analysis to identify potentially
+vulnerable repositories at scale.
 
 ## Version 1.7
 
 Gato version 1.7 introduces the **Actions Artifacts Secrets Scanner**.
 
-The Actions Artifacts Secrets Scanner enumerates [GitHub Actions workflow artifacts](https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/storing-and-sharing-data-from-a-workflow) for secrets. Praetorian researchers have leveraged the scanner to identify critical vulnerabilities in several prominent open-sourced projects. Details of these vulnerabilities will be released once the disclosure processes are complete. This work was initially inspired by research from [Palo Alto Networks](https://unit42.paloaltonetworks.com/github-repo-artifacts-leak-tokens/). 
+The Actions Artifacts Secrets Scanner enumerates [GitHub Actions workflow
+artifacts](https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/storing-and-sharing-data-from-a-workflow)
+for secrets. Praetorian researchers have leveraged the scanner to identify
+critical vulnerabilities in several prominent open-sourced projects. Details of
+these vulnerabilities will be released once the disclosure processes are
+complete. This work was initially inspired by research from [Palo Alto
+Networks](https://unit42.paloaltonetworks.com/github-repo-artifacts-leak-tokens/).
 
 The Actions Artifacts Secrets Scanner performs the following actions:
 1. Downloads GitHub Actions workflow artifacts from the target repository
 2. Recursively extracts the downloaded artifacts
-3. Scans the artifacts for secrets with [NoseyParker](https://github.com/praetorian-inc/noseyparker)
+3. Scans the artifacts for secrets with
+   [NoseyParker](https://github.com/praetorian-inc/noseyparker)
 4. Reports the results
 
-[NoseyParker](https://github.com/praetorian-inc/noseyparker/releases) must be installed in the $PATH of the system running the Actions Artifacts Secrets Scanner.
+[NoseyParker](https://github.com/praetorian-inc/noseyparker/releases) must be
+installed in the $PATH of the system running the Actions Artifacts Secrets
+Scanner.
 
-Secrets in public workflow artifacts can contain many false positives. By default, the Actions Artifacts Secrets Scanner excludes rules and results associated with common false positives. To include all secrets scanning results, you can use the `--include_all_artifact_secrets` flag.
+Secrets in public workflow artifacts can contain many false positives. By
+default, the Actions Artifacts Secrets Scanner excludes rules and results
+associated with common false positives. To include all secrets scanning results,
+you can use the `--include_all_artifact_secrets` flag.
 
-Here is an example command that runs the Actions Artifacts Secrets Scanner on a list of GitHub organizations, disables self-hosted runner enumeration, includes all artifact secret results, and outputs to a JSON file.
+Here is an example command that runs the Actions Artifacts Secrets Scanner on a
+list of GitHub organizations, disables self-hosted runner enumeration, includes
+all artifact secret results, and outputs to a JSON file.
 
 ```
 gato e --enum_wf_artifacts --include_all_artifact_secrets --skip_sh_runner_enum -O testorgs.txt  -oJ testorgoutput.json
 ```
 
-By default, the Actions Artifacts Secrets Scanner imposes the following limitations to reduce the time spent on a single repository:
+By default, the Actions Artifacts Secrets Scanner imposes the following
+limitations to reduce the time spent on a single repository:
 - Only downloads one artifact per name
 - Downloads a maximum of 50 artifacts per repository
 - Downloads a maximum of 10 files greater than 536 MBs
 - Does not download any files greater than 2.68 GBs
 
-These constraints were optimized such that the Actions Artifacts Secrets Scanner can scan the top 200 GitHub organizations within 48 hours. If you want to modify these constraints, you can update them in the `scan_wf_artifacts()` function of `gato/enumerate/repository.py`.
+These constraints were optimized such that the Actions Artifacts Secrets Scanner
+can scan the top 200 GitHub organizations within 48 hours. If you want to modify
+these constraints, you can update them in the `scan_wf_artifacts()` function of
+`gato/enumerate/repository.py`.
 
 ## New Features
 
@@ -88,7 +111,7 @@ These constraints were optimized such that the Actions Artifacts Secrets Scanner
 
 Gato supports OS X and Linux with at least **Python 3.7**.
 
-In order to install the tool, simply clone the repository and use `pip install`. We 
+In order to install the tool, simply clone the repository and use `pip install`. We
 recommend performing this within a virtual environment.
 
 ```
@@ -99,57 +122,61 @@ source venv/bin/activate
 pip install .
 ```
 
-Gato also requires that `git` version `2.27` or above is installed and on the 
-system's PATH. In order to run the fork PR attack module, `sed` must also be 
+Gato also requires that `git` version `2.27` or above is installed and on the
+system's PATH. In order to run the fork PR attack module, `sed` must also be
 installed and present on the system's path.
 
 #### Dev Branch
 
-We maintain a development branch that contains newer Gato features that are not yet added to main.
-There is an increased chance you will run into bugs; however, we still run our integration test
-suite on the `dev` branch, so there should not be any _blatant_ bugs.
+We maintain a development branch that contains newer Gato features that are not
+yet added to main. There is an increased chance you will run into bugs; however,
+we still run our integration test suite on the `dev` branch, so there should not
+be any _blatant_ bugs.
 
-If you want to use the `dev` branch, just check it out prior to running pip install - that's it!
+If you want to use the `dev` branch, just check it out prior to running pip
+install - that's it!
 
-If you do run into any bugs for your specific use case, by all means open an issue!
-
+If you do run into any bugs for your specific use case, by all means open an
+issue!
 
 ### Usage
 
 After installing the tool, it can be launched by running `gato` or
 `praetorian-gato`.
 
-We recommend viewing the parameters for the base tool using `gato -h`, and the 
+We recommend viewing the parameters for the base tool using `gato -h`, and the
 parameters for each of the tool's modules by running the following:
 
 * `gato search -h`
 * `gato enum -h`
 * `gato attack -h`
 
-The tool requires a GitHub classic  or app installation token in order to function. To create one, log
-in to GitHub and go to [GitHub Developer
-Settings](https://github.com/settings/tokens) 
-and select `Generate New Token` and then `Generate new token (classic)`.
+The tool requires a GitHub classic or app installation token in order to
+function. To create one, log in to GitHub and go to [GitHub Developer
+Settings](https://github.com/settings/tokens) and select `Generate New Token`
+and then `Generate new token (classic)`.
 
-After creating this token set the `GH_TOKEN` environment variable within your 
-shell by running `export GH_TOKEN=<YOUR_CREATED_TOKEN>`. Alternatively, store 
-the token within a secure password manager and enter it when the application 
+After creating this token set the `GH_TOKEN` environment variable within your
+shell by running `export GH_TOKEN=<YOUR_CREATED_TOKEN>`. Alternatively, store
+the token within a secure password manager and enter it when the application
 prompts you.
 
-If creating a GitHub App Installation token, the app needs to have at least `Actions:read` and `Contents:read`ß to execute the enumeration modules.
+If creating a GitHub App Installation token, the app needs to have at least
+`Actions:read` and `Contents:read` to execute the enumeration modules.
 
-For troubleshooting and additional details, such as installing in developer 
+For troubleshooting and additional details, such as installing in developer
 mode or running unit tests, please see the [wiki](https://github.com/praetorian-inc/gato/wiki).
 
 ## Documentation
 
-Please see the [wiki](https://github.com/praetorian-inc/gato/wiki)
- for detailed documentation, as well as [OpSec](https://github.com/praetorian-inc/gato/wiki/opsec) considerations 
-for the tool's various modules!
+Please see the [wiki](https://github.com/praetorian-inc/gato/wiki) for detailed
+documentation, as well as
+[OpSec](https://github.com/praetorian-inc/gato/wiki/opsec) considerations for
+the tool's various modules!
 
 ## Bugs
 
-If you believe you have identified a bug within the software, please open an 
+If you believe you have identified a bug within the software, please open an
 issue containing the tool's output, along with the actions you were trying to
 conduct.
 
@@ -158,12 +185,13 @@ If you are unsure if the behavior is a bug, use the discussions section instead!
 
 ## Contributing
 
-Contributions are welcome! Please [review](https://github.com/praetorian-inc/gato/wiki/Project-Design) our design methodology and coding 
-standards before working on a new feature!
+Contributions are welcome! Please
+[review](https://github.com/praetorian-inc/gato/wiki/Project-Design) our design
+methodology and coding standards before working on a new feature!
 
-Additionally, if you are proposing significant changes to the tool, please
-[open an issue](https://github.com/praetorian-inc/gato/issues/new) to
-start a conversation about the motivation for the changes.
+Additionally, if you are proposing significant changes to the tool, please [open
+an issue](https://github.com/praetorian-inc/gato/issues/new) to start a
+conversation about the motivation for the changes.
 
 ## License
 

--- a/gato/cli/cli.py
+++ b/gato/cli/cli.py
@@ -114,7 +114,7 @@ def validate_arguments(args, parser):
         )
 
     if not ("ghp_" in gh_token or "gho_" in gh_token or "ghu_" in
-            gh_token or re.match('^[a-fA-F0-9]{40}$', gh_token)):
+            gh_token or "ghs_" in gh_token or re.match('^[a-fA-F0-9]{40}$', gh_token)):
         parser.error(f"{Fore.RED}[!]{Style.RESET_ALL} Provided GitHub PAT is"
                      " malformed!")
 

--- a/gato/cli/cli.py
+++ b/gato/cli/cli.py
@@ -262,8 +262,7 @@ def enumerate(args, parser):
         orgs = gh_enumeration_runner.validate_only()
     elif args.self_enumeration:
         if gh_enumeration_runner.api.is_app_token():
-            repo_list = gh_enumeration_runner.github_app_self_enumeration()
-            repos = gh_enumeration_runner.enumerate_repos(repo_list)
+            repos = gh_enumeration_runner.app_enumeration()
         else:
             orgs = gh_enumeration_runner.self_enumeration()
     elif args.target:

--- a/gato/cli/cli.py
+++ b/gato/cli/cli.py
@@ -261,7 +261,11 @@ def enumerate(args, parser):
     if args.validate:
         orgs = gh_enumeration_runner.validate_only()
     elif args.self_enumeration:
-        orgs = gh_enumeration_runner.self_enumeration()
+        if gh_enumeration_runner.api.is_app_token():
+            repo_list = gh_enumeration_runner.github_app_self_enumeration()
+            repos = gh_enumeration_runner.enumerate_repos(repo_list)
+        else:
+            orgs = gh_enumeration_runner.self_enumeration()
     elif args.target:
         orgs = [gh_enumeration_runner.enumerate_organization(
             args.target

--- a/gato/enumerate/enumerate.py
+++ b/gato/enumerate/enumerate.py
@@ -29,8 +29,6 @@ class Enumerator:
         wf_artifacts_enum: str = False,
         skip_sh_runner_enum: str = False,
         include_all_artifact_secrets: bool = False,
-        app_installation_repos: list = [],
-
     ):
         """Initialize enumeration class with arguments sent by user.
 
@@ -68,52 +66,53 @@ class Enumerator:
         self.repo_e = RepositoryEnum(self.api, skip_log, output_yaml,
                                      skip_sh_runner_enum)
         self.org_e = OrganizationEnum(self.api)
-        self.app_installation_repos = app_installation_repos
+        self.app_installed_repos = None
 
     def __setup_user_info(self):
-
-        if not self.user_perms and self.api.is_app_token():
-            installation_info = self.api.get_installation_repos()
-
-            if installation_info:
-                count = installation_info["total_count"]
-                self.app_installation_repos = installation_info["repositories"]
-                if count > 0:
-                    Output.info(
-                        f"Gato is using valid a GitHub App installation token!"
-                    )
-                    self.user_perms = {
-                        "user": "Github App",
-                        "scopes": [],
-                        "name": "GATO App Mode",
-                    }
-
-                    return True
-                else:
-                    return False        
-
         if not self.user_perms:
-            self.user_perms = self.api.check_user()
-            if not self.user_perms:
-                Output.error("This token cannot be used for enumeration!")
-                return False
+            if self.api.is_app_token():
+                Output.info("Gato is performing GitHub App enumeration!")
 
-            Output.info(
-                    "The authenticated user is: "
-                    f"{Output.bright(self.user_perms['user'])}"
-            )
-            if len(self.user_perms["scopes"]):
-                Output.info(
-                    "The GitHub Classic PAT has the following scopes: "
-                    f'{Output.yellow(", ".join(self.user_perms["scopes"]))}'
-                )
+                installed_repos = self.api.get_app_installations()
+                if not installed_repos:
+                    Output.error("Failed to validate the GitHub App installation token.")
+                    return False
+
+                count = installed_repos["total_count"]
+                repos_j = installed_repos["repositories"]
+
+                if count <= 0:
+                    Output.error("No installed repositories were found!")
+
+                self.user_perms = {
+                    "user": "Github App",
+                    "scopes": [],
+                    "name": "GATO App Mode",
+                }
+
+                self.app_installed_repos = [item["owner"]["login"] + "/" + item["name"] for item in repos_j]
             else:
-                Output.warn("The token has no scopes!")
+                self.user_perms = self.api.check_user()
+                if not self.user_perms:
+                    Output.error("This token cannot be used for enumeration!")
+                    return False
 
-            if self.wf_artifacts_enum and "repo" not in self.user_perms["scopes"]:
-                Output.error("The token needs repo scope to retrieve workflow artifacts. Skipping workflow artifact secrets scanning.")
-                self.wf_artifacts_enum = False
+                Output.info(
+                        "The authenticated user is: "
+                        f"{Output.bright(self.user_perms['user'])}"
+                )
+                if len(self.user_perms["scopes"]):
+                    Output.info(
+                        "The GitHub Classic PAT has the following scopes: "
+                        f'{Output.yellow(", ".join(self.user_perms["scopes"]))}'
+                    )
+                else:
+                    Output.warn("The token has no scopes!")
 
+                if self.wf_artifacts_enum and "repo" not in self.user_perms["scopes"]:
+                    Output.error("The token needs repo scope to retrieve workflow artifacts. "
+                                 "Skipping workflow artifact secrets scanning.")
+                    self.wf_artifacts_enum = False
         return True
 
     def validate_only(self):
@@ -167,26 +166,28 @@ class Enumerator:
         org_wrappers = list(map(self.enumerate_organization, orgs))
 
         return org_wrappers
-    
-    def github_app_self_enumeration(self):
-        
-        self.__setup_user_info()
 
-        if not self.user_perms:
+    def app_enumeration(self):
+        """Enumerates availabe repositories associated with the authenticated GitHub app.
+
+        Returns:
+            bool: False if the token is not valid for enumeration.
+        """
+        if not self.__setup_user_info():
             return False
 
-        repos = [item["owner"]["login"] + "/" + item["name"] for item in self.app_installation_repos]
-
         Output.info(
-            f'The GitHub App Installation token has access to {len(repos)} '
-            'repositories! Note that Gato does not determine GitHub App Installation token access level and will only perform read-level analysis.'
-        )
+            f'The GitHub App Installation token has access to {len(self.app_installed_repos)} '
+            'repositories! Note that Gato does not determine GitHub App '
+            'Installation token access level and will only perform read-level '
+            'analysis.')
 
-        for repo in repos:
+        Output.info("Accessible Repositories:")
+        for repo in self.app_installed_repos:
             Output.tabbed(f"{Output.bright(repo)}")
 
-        return repos
-
+        Output.info("Enumerating each repository")
+        return self.enumerate_repos(self.app_installed_repos)
 
     def enumerate_organization(self, org: str):
         """Enumerate an entire organization, and check everything relevant to

--- a/gato/enumerate/enumerate.py
+++ b/gato/enumerate/enumerate.py
@@ -69,6 +69,26 @@ class Enumerator:
         self.org_e = OrganizationEnum(self.api)
 
     def __setup_user_info(self):
+
+        if not self.user_perms and self.api.is_app_token():
+            installation_info = self.api.get_installation_repos()
+
+            if installation_info:
+                count = installation_info["total_count"]
+                if count > 0:
+                    Output.info(
+                        f"Gato is using valid a GitHub App installation token!"
+                    )
+                    self.user_perms = {
+                        "user": "Github App",
+                        "scopes": [],
+                        "name": "GATO App Mode",
+                    }
+
+                    return True
+                else:
+                    return False        
+
         if not self.user_perms:
             self.user_perms = self.api.check_user()
             if not self.user_perms:

--- a/gato/enumerate/repository.py
+++ b/gato/enumerate/repository.py
@@ -264,7 +264,7 @@ class RepositoryEnum():
 
         repository.update_time()
 
-        if not repository.can_pull():
+        if not repository.can_pull() and not self.api.is_app_token():
             Output.error("The user cannot push or pull, skipping.")
             return
 

--- a/gato/github/api.py
+++ b/gato/github/api.py
@@ -567,8 +567,15 @@ class Api():
                 " PAT permission level!"
             )
 
-    def get_installation_repos(self):
-        """ """
+    def get_app_installations(self):
+        """Checks for repositories associated with the authenticated GitHub App
+
+        Returns:
+            dict: Dictionary containingg information about the repos.
+        """
+        if not self.is_app_token():
+            return None
+
         response = self.call_get("/installation/repositories")
         if response.status_code == 200:
             return response.json()

--- a/gato/github/api.py
+++ b/gato/github/api.py
@@ -567,6 +567,16 @@ class Api():
                 " PAT permission level!"
             )
 
+    def get_installation_repos(self):
+        """ """
+        response = self.call_get("/installation/repositories")
+        if response.status_code == 200:
+            return response.json()
+
+    def is_app_token(self):
+        """Returns if the API is using a GitHub App installation token."""
+        return self.pat.startswith("ghs_")
+
     def check_org_repos(self, org: str, type: str):
         """Check repositories present within an organization.
 


### PR DESCRIPTION
the enumeration module now supports using github app installation tokens (ghs_). Needed for Chariot. 