### PR TITLE
header check bug fix in rate limit checking

### DIFF
--- a/gato/github/api.py
+++ b/gato/github/api.py
@@ -85,7 +85,7 @@ class Api():
         """Checks the rate limit, and pauses Gato execution until the rate
         limit resets.
         """
-        if 'X-Ratelimit-Remaining' in headers and \
+        if 'X-Ratelimit-Remaining' in headers and 'X-Ratelimit-Resource' in headers and \
                 int(headers['X-Ratelimit-Remaining']) < int(headers['X-RateLimit-Limit']) // 20 and \
                 headers['X-Ratelimit-Resource'] == 'core':
             gh_date = headers['Date']


### PR DESCRIPTION
The conditional on this line https://github.com/praetorian-inc/gato/blob/main/gato/github/api.py#L88 checks two parameters in the headers, but only verifies if one of them is in the list of headers. Unclear why, but this broke a scan when the `X-Ratelimit-Remaining` was in the headers, but `X-Ratelimit-Resource` was not

This PR simply verifies the second header is within the list of headers